### PR TITLE
Return typed statements in the typechecker

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -32,10 +32,11 @@ main = do
       error "Parser failed with exit code -1"
     Right res -> pure res
 
-  ast <- case typecheck ast of
+  (tast, warnings) <- case typecheck ast of
     Left diag -> do
       printDiagnostic withColor stderr (diag <~< (file, lines $ Text.unpack content))
       error "Typechecker failed with exit code -1"
     Right res -> pure res
+  printDiagnostic withColor stderr (warnings <~< (file, lines $ Text.unpack content))
 
   pure ()

--- a/lib/nsc-core/src/Language/NStar/Syntax/Core.hs
+++ b/lib/nsc-core/src/Language/NStar/Syntax/Core.hs
@@ -74,6 +74,9 @@ data Type where
   ForAll :: [(Located Type, Located Kind)]                  -- ^ Variables along with their 'Kind's
          -> Located Type
          -> Type
+  -- | Register type
+  Register :: Natural                                       -- ^ Register size
+           -> Type
 
 deriving instance Show Type
 deriving instance Eq Type

--- a/lib/nsc-core/src/Language/NStar/Typechecker/Core.hs
+++ b/lib/nsc-core/src/Language/NStar/Typechecker/Core.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GADTs #-}
+
 {-|
   Module: Language.NStar.Typechecker.Core
   Description: NStar's typechecking core language
@@ -7,8 +9,26 @@
 -}
 
 module Language.NStar.Typechecker.Core
-( -- * Re-exports
+(
+  TypedProgram(..)
+, TypedStatement(..)
+,  -- * Re-exports
   module Language.NStar.Syntax.Core
 ) where
 
-import Language.NStar.Syntax.Core (Type(..), Kind(..), Register(..))
+import Language.NStar.Syntax.Core (Type(..), Kind(..), Register(..), Instruction(..))
+import Data.Located (Located)
+import Data.Text (Text)
+
+data TypedProgram = TProgram [Located TypedStatement]
+
+data TypedStatement where
+  -- | A label stripped off its context.
+  TLabel :: Located Text         -- ^ the name of the label
+         -> TypedStatement
+  -- | An instruction with type information attached to it.
+  TInstr :: Located Instruction  -- ^ the typed instruction
+         -> [Located Type]       -- ^ type information of the arguments
+                                 --
+                                 -- Note: we take a list of types because all instructions do not necessarily share the same number of arguments
+         -> TypedStatement

--- a/lib/nsc-typechecker/nsc-typechecker.cabal
+++ b/lib/nsc-typechecker/nsc-typechecker.cabal
@@ -13,6 +13,7 @@ library
       Language.NStar.Typechecker.Env
       Language.NStar.Typechecker.Errors
       Language.NStar.Typechecker.Free
+      Language.NStar.Typechecker.Instructions
       Language.NStar.Typechecker.Kinds
       Language.NStar.Typechecker.Pretty
       Language.NStar.Typechecker.Subst

--- a/lib/nsc-typechecker/nsc-typechecker.cabal
+++ b/lib/nsc-typechecker/nsc-typechecker.cabal
@@ -3,8 +3,6 @@ cabal-version: 1.12
 -- This file has been generated from package.yaml by hpack version 0.34.2.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 9a70ab838c4fb20017c5e1a78d4a669ab4d37b126857ce575432866c5a34ceb6
 
 name:           nsc-typechecker
 version:        0.0.1.0
@@ -18,6 +16,7 @@ library
       Language.NStar.Typechecker.Kinds
       Language.NStar.Typechecker.Pretty
       Language.NStar.Typechecker.Subst
+      Language.NStar.Typechecker.TC
       Language.NStar.Typechecker.Types
   other-modules:
       Paths_nsc_typechecker

--- a/lib/nsc-typechecker/src/Language/NStar/Typechecker/Free.hs
+++ b/lib/nsc-typechecker/src/Language/NStar/Typechecker/Free.hs
@@ -42,6 +42,7 @@ instance Free Type where
   freeVars (Var _)           = mempty
   freeVars (Signed _)        = mempty
   freeVars (Unsigned _)      = mempty
+  freeVars (Register _)      = mempty
   -- Please refrain yourself from putting the three above cases under the same pattern "_".
   -- Those three are separated in order to keep GHC's warning about incomplete pattern matchings.
   --

--- a/lib/nsc-typechecker/src/Language/NStar/Typechecker/Instructions.hs
+++ b/lib/nsc-typechecker/src/Language/NStar/Typechecker/Instructions.hs
@@ -1,0 +1,188 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.NStar.Typechecker.Instructions where
+
+import Language.NStar.Typechecker.Errors
+import Language.NStar.Typechecker.TC
+import Language.NStar.Typechecker.Free
+import Language.NStar.Typechecker.Subst
+import Language.NStar.Typechecker.Core
+import Language.NStar.Syntax.Core (Expr(..), Immediate(..))
+import Data.Located (Located(..), unLoc, getPos, Position)
+import qualified Data.Map as Map
+import Control.Monad.State (gets)
+import Control.Monad.Except (throwError, catchError)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Maybe (fromJust)
+import Data.Foldable (fold)
+
+tc_ret :: Position -> Typechecker [Located Type]
+tc_ret p = do
+  -- `reŧ` needs the return address on top of the stack.
+  -- Any remainding register values are left to the developer to choose.
+  --
+  -- So when a `reŧ` comes, the stack (so `%rsp` on x64) needs to be
+  -- `sptr *r0::s0` where `r0` is a record.
+  --
+  --
+  -- According to the x86 docs, we could also make `ret` take one parameter:
+  -- a number of bytes to pop off the stack, after popping the return address off.
+  -- While this may be useful, I won't handle this because it won't probably
+  -- be useful in N*, as a language backend.
+
+  -- if the unification suceeded, we know that there is a pointer to some sort of context
+  -- on top of the stack, which we may pop and compare to the current context.
+
+  -- TODO: check that when can return
+  -- 1- we must have crossed a label at some point. We will take the last found
+  -- 2- we must be able to extract a pointer to a context, on top of the stack
+  -- 3- everything we want to return in the context must already be found in the current context
+
+  funName <- gets (currentLabel . snd) >>= \case
+    Nothing -> throwError (ToplevelReturn p)
+    Just l  -> pure l
+
+
+  stackVar <- freshVar "@" p
+  let minimalCtx = Record (Map.singleton (RSP :@ p) (SPtr (Cons (Ptr (Record mempty :@ p) :@ p) stackVar :@ p) :@ p)) :@ p
+  currentCtx <- gets (currentTypeContext . snd)
+
+  catchError (unify minimalCtx (Record currentCtx :@ p))
+             (const $ throwError (NoReturnAddress p currentCtx))
+
+
+  let removeStackTop (SPtr (Cons _ t :@ _) :@ p1) = SPtr t :@ p1
+      removeStackTop (t :@ _)                     = error $ "Cannot extract stack top of type '" <> show t <> "'"
+
+      getStackTop (SPtr (Cons t _ :@ _) :@ _) = t
+      getStackTop (t :@ _)                    = error $ "Cannot extract stack top of type '" <> show t <> "'"
+
+  let returnShouldBe = Ptr (Record (Map.adjust removeStackTop (RSP :@ p) currentCtx) :@ p) :@ p
+      returnCtx = getStackTop $ fromJust (Map.lookup (RSP :@ p) currentCtx)
+
+  let changeErrorIfMissingKey (DomainsDoNotSubtype (m1 :@ _) (m2 :@ _)) =
+        ContextIsMissingOnReturn p (getPos returnCtx) (Map.keysSet m1 Set.\\ Map.keysSet m2)
+      changeErrorIfMissingKey e                                         = e
+
+  catchError (unify returnCtx returnShouldBe)
+             (throwError . changeErrorIfMissingKey)
+  pure []
+
+
+tc_mov :: Located Expr -> Located Expr -> Position -> Typechecker [Located Type]
+tc_mov (src :@ p1) (dest :@ p2) p = do
+  -- There are many ways of handling `mov`s, and it all depends on what arguments are given.
+  --
+  -- > mov <immediate>, <register>
+  -- sets "<register>: typeof (<immediate>)" in the current context
+  -- > mov <register2>, <register1>
+  -- sets "<register1>: typeof (<register2>)" in the current context
+  -- > mov <immediate>, (<address:type>)
+  -- TODO: UNSAFE ???
+  -- > mov (<address:type>), <register>
+  -- UNSAFE sets "<register>: <type>" in the current context
+  -- > mov (<address2:type2>), (<address1:type1>)
+  -- TODO: UNSAFE ???
+  -- > mov <immediate>, <offset>(<register>)
+  -- UNSAFE assert that `<register>: *typeof (<immediate>)` and leave the context untouched
+  -- > mov <register2>, <offset>(<register1>)
+  -- UNSAFE assert that `<register1>: *typeof (<register2>)` and leave the context untouched
+  --
+  --
+  -- For all those assertions, we also have to check that type sizes do match.
+  case (src, dest) of
+    (Imm i, Reg r) -> do
+      ty <- typecheckExpr src p1
+      -- TODO: size check
+      -- At the moment, this isn't a problem: we only handle immediates that are actually
+      -- smaller than the max size (8 bytes) possible.
+      gets (currentTypeContext . snd) >>= setCurrentTypeContext . Map.insert r ty
+      pure [ty, Register 64 :@ p2] -- TODO: fetch actual size of register
+    (Reg r1, Reg r2) -> do
+      ty1 <- typecheckExpr src p1
+      -- TODO: size check
+      -- No need at the moment, we only have 8-bytes big registers.
+      gets (currentTypeContext . snd) >>= setCurrentTypeContext . Map.insert r2 ty1
+      pure [Register 64 :@ p1, Register 64 :@ p2] -- TODO: fetch actual size of register
+    _ -> error $ "Missing `mov` typechecking implementation for '" <> show src <> "' and '" <> show dest <> "'."
+
+---------------------------------------------------------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------------------------------------------
+
+typecheckExpr :: Expr -> Position -> Typechecker (Located Type)
+typecheckExpr (Imm (I _ :@ _)) p  = pure (Unsigned 64 :@ p)
+typecheckExpr (Imm (C _ :@ _)) p  = pure (Signed 8 :@ p)
+typecheckExpr (Reg r) p           = do
+  ctx <- gets (currentTypeContext . snd)
+  maybe (throwError (RegisterNotFoundInContext (unLoc r) p (Map.keysSet ctx))) pure (Map.lookup r ctx)
+typecheckExpr (Indexed _ e) p     = typecheckExpr (unLoc e) p
+typecheckExpr e p                 = error $ "Unimplemented `typecheckExpr` for '" <> show e <> "'."
+
+--------------------------------------------------------------------------------
+
+-- | Generates a fresh free type variable based on a given prefix, for the current source position.
+freshVar :: Text -> Position -> Typechecker (Located Type)
+freshVar prefix pos = do
+  n <- gets fst
+  incrementCounter
+  pure (FVar ((prefix <> Text.pack (show n)) :@ pos) :@ pos)
+
+-- | Unifies two types, and returns the substitution from the first to the second.
+unify :: (t ~ Located Type) => t -> t -> Typechecker (Subst t)
+unify (t1 :@ p1) (t2 :@ p2) = case (t1, t2) of
+  _ | t1 == t2 -> pure mempty
+  -- Signed types are all coercible.
+  (Signed _, Signed _) -> pure mempty
+  -- Unsigned types are all coercible.
+  (Unsigned _, Unsigned _) -> pure mempty
+  -- Signed and unsigned integers can also be coerced to each other.
+  (Signed _, Unsigned _) -> pure mempty
+  (Unsigned _, Signed _) -> pure mempty
+  -- Two pointers are coercible if their pointed types are coercible.
+  (Ptr t1, Ptr t2) -> unify t1 t2
+  (SPtr t1, SPtr t2) -> unify t1 t2
+  -- Free type variables can be bound to anything as long as it does not create an infinite type.
+  (FVar v, t) -> bind (v, p1) (t, p2)
+  (t, FVar v) -> bind (v, p2) (t, p1)
+  -- FIXME: Handle records properly
+  (Record m1, Record m2) -> do
+    -- @m2@ should contain at least all the keys in @m1@:
+    let k1 = Map.keysSet m1
+        k2 = Map.keysSet m2
+    if not (k1 `Set.isSubsetOf` k2)
+    then throwError (DomainsDoNotSubtype (m1 :@ p1) (m2 :@ p2))
+    else do
+      -- All the values from the keys of @m1@ in @m2@ should be 'unify'able with the values in @m1@:
+      let doUnify k v = catchError (unify v (m2 Map.! k)) (\ e -> throwError $ RecordUnify e (m1 :@ p1) (m2 :@ p2))
+      subs <- fold <$> Map.traverseWithKey doUnify m1
+      pure subs
+  -- A stack constructor can be unified to another stack constructor if
+  -- both stack head and stack tail of each stack can be unified.
+  (Cons t1 t3, Cons t2 t4) -> unifyMany [t1, t3] [t2, t4]
+  -- Any other combination is not possible
+  _ -> throwError (Uncoercible (t1 :@ p1) (t2 :@ p2))
+
+-- | Unifies many types, yielding the composition of all the substitutions created.
+unifyMany :: (t ~ Located Type) => [t] -> [t] -> Typechecker (Subst t)
+unifyMany [] []         = pure mempty
+unifyMany (x:xs) (y:ys) = do
+  sub1 <- unify x y
+  sub2 <- unifyMany (apply sub1 xs) (apply sub1 ys)
+  pure (sub1 <> sub2)
+unifyMany l r           =
+  error ("Could not unify " <> show l <> " and " <> show r <> " because they aren't of the same size.")
+
+-- | Tries to bind a free type variable to a type, yielding a substitution from the variable to the type if
+--   it succeeded.
+bind :: (Located Text, Position) -> (Type, Position) -> Typechecker (Subst (Located Type))
+bind (var, p1) (FVar v, p2)
+  | var == v              = pure mempty
+bind (var, p1) (ty, p2)
+  | occursCheck var ty    = throwError (InfiniteType (ty :@ p2) var)
+  | otherwise             = pure (Subst (Map.singleton var (ty :@ p2)))
+ where
+   occursCheck v t = v `Set.member` freeVars t

--- a/lib/nsc-typechecker/src/Language/NStar/Typechecker/Kinds.hs
+++ b/lib/nsc-typechecker/src/Language/NStar/Typechecker/Kinds.hs
@@ -71,6 +71,8 @@ kindcheckType ctx (Record mappings :@ p)                 =
        -- FIXME: Kind checking does not take into account the size of the types, so if they are sized, they all are 8-bytes big at the moment.
  where handleTypeFromRegister (RSP :@ _) ty@(_ :@ p) = requireStackType p =<< kindcheckType ctx ty
        handleTypeFromRegister _ ty@(_ :@ p)          = liftA2 (*>) (requireDataType p) (requireSized p) =<< kindcheckType ctx ty
+kindcheckType _ (Register _ :@ p)                        = pure (T8 :@ p)
+     -- NOTE: just a kind placeholder. rN types never appear after parsing.
 
 --------------------------------------------------------------------------------------------
 

--- a/lib/nsc-typechecker/src/Language/NStar/Typechecker/Pretty.hs
+++ b/lib/nsc-typechecker/src/Language/NStar/Typechecker/Pretty.hs
@@ -30,6 +30,7 @@ instance PrettyText t => PrettyText (Located t) where
 instance PrettyText Type where
   prettyText (Var v) = text (Text.unpack (unLoc v))
   prettyText (FVar v) = text (Text.unpack (unLoc v))
+  prettyText (Register n) = text "r" <> text (show n)
   prettyText (Signed n) = text "s" <> text (show n)
   prettyText (Unsigned n) = text "u" <> text (show n)
   prettyText (Cons t1 t2) = prettyText t1 <> colon <> colon <> prettyText t2

--- a/lib/nsc-typechecker/src/Language/NStar/Typechecker/Pretty.hs
+++ b/lib/nsc-typechecker/src/Language/NStar/Typechecker/Pretty.hs
@@ -13,7 +13,7 @@
 module Language.NStar.Typechecker.Pretty where
 
 import Text.Diagnose (PrettyText(..))
-import Text.PrettyPrint.ANSI.Leijen (text, (<+>), encloseSep, lbrace, rbrace, comma, colon, dot, hsep)
+import Text.PrettyPrint.ANSI.Leijen (text, (<+>), encloseSep, lbrace, rbrace, comma, colon, dot, hsep, vsep)
 import Language.NStar.Typechecker.Core
 import qualified Data.Text as Text
 import Data.Located (unLoc, Located)
@@ -52,3 +52,12 @@ instance PrettyText Register where
       f RDI = "rdi"
       f RBP = "rbp"
       f RSP = "rsp"
+
+instance PrettyText TypedProgram where
+  prettyText (TProgram stts) = vsep (fmap prettyText stts)
+
+instance PrettyText TypedStatement where
+  prettyText (TLabel l)    = text (Text.unpack (unLoc l)) <> colon
+  prettyText (TInstr i ts) = text "_" <+> hsep (fmap pprint ts)
+                       --         ^^^ waiting to implement `PrettyText` for `Instruction`
+    where pprint ty = text "@" <> prettyText ty

--- a/lib/nsc-typechecker/src/Language/NStar/Typechecker/Subst.hs
+++ b/lib/nsc-typechecker/src/Language/NStar/Typechecker/Subst.hs
@@ -53,6 +53,7 @@ instance Substitutable Type where
   apply _ t@(Signed _)              = t
   apply _ t@(Unsigned _)            = t
   apply _ t@(Var _)                 = t
+  apply _ t@(Register _)            = t
   apply s (Cons t1 t2)              = Cons (apply s t1) (apply s t2)
   apply (Subst s) t@(FVar v)        = fromMaybe t (unLoc <$> Map.lookup v s)
   apply s (Record rts)              = Record (apply s <$> rts)

--- a/lib/nsc-typechecker/src/Language/NStar/Typechecker/TC.hs
+++ b/lib/nsc-typechecker/src/Language/NStar/Typechecker/TC.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Language.NStar.Typechecker.TC where
+
+import Control.Monad.State (StateT, modify)
+import Control.Monad.Writer (WriterT)
+import Control.Monad.Except (Except)
+import Data.Map (Map)
+import Language.NStar.Typechecker.Env (Env)
+import qualified Language.NStar.Typechecker.Env as Env
+import Data.Located (Located)
+import Data.Text (Text)
+import Language.NStar.Typechecker.Core
+import Data.Bifunctor (first, second)
+import Language.NStar.Typechecker.Errors (TypecheckError)
+
+type Typechecker a = StateT (Integer, Context) (WriterT [TypecheckError] (Except TypecheckError)) a
+
+-- | The data type of contexts in typechecking.
+data Context
+  = Ctx
+  { typeEnvironment    :: Env Type                               -- ^ An 'Env'ironment containing labels associated to their expected contexts
+  , currentTypeContext :: Map (Located Register) (Located Type)  -- ^ The current typechecking context
+  , currentKindContext :: Map (Located Text) (Located Kind)      -- ^ The current kindchecking context
+  , currentLabel       :: Maybe (Located Text)                   -- ^ The last crossed label
+  }
+
+-- | Adds a type to the environment.
+addType :: Located Text -> Located Type -> Typechecker ()
+addType k v = modify $ second modifyTypeContext
+  where modifyTypeContext ctx@Ctx{..} = ctx { typeEnvironment = Env.insert k v typeEnvironment }
+
+-- | Increments the counter in the 'State' by one, effectively simulating a @counter++@ operation.
+incrementCounter :: Typechecker ()
+incrementCounter = modify $ first (+ 1)
+
+setCurrentTypeContext :: Map (Located Register) (Located Type) -> Typechecker ()
+setCurrentTypeContext newCtx = modify $ second putContext
+  where putContext ctx = ctx { currentTypeContext = newCtx }
+
+setCurrentKindContext :: Map (Located Text) (Located Kind) -> Typechecker ()
+setCurrentKindContext newCtx = modify $ second putContext
+  where putContext ctx = ctx { currentKindContext = newCtx }
+
+setTypeEnvironment :: Env Type -> Typechecker ()
+setTypeEnvironment newEnv = modify $ second setTypeEnv
+  where setTypeEnv ctx = ctx { typeEnvironment = newEnv }
+
+setLabel :: Located Text -> Typechecker ()
+setLabel n = modify $ second setLbl
+  where setLbl ctx = ctx { currentLabel = Just n }
+
+--------------------------------------------------------

--- a/lib/nsc-typechecker/src/Language/NStar/Typechecker/Types.hs
+++ b/lib/nsc-typechecker/src/Language/NStar/Typechecker/Types.hs
@@ -39,11 +39,12 @@ import Data.Foldable (fold)
 import Debug.Trace (trace)
 import Data.Maybe (fromJust)
 import Language.NStar.Typechecker.Kinds (kindcheck)
+import Language.NStar.Typechecker.Instructions
 import Language.NStar.Typechecker.TC
 
 
 -- | Runs the typechecker on a given program, returning either an error or a well-formed program.
-typecheck :: Program -> Either (Diagnostic s String m) (Program, [Report String])
+typecheck :: Program -> Either (Diagnostic s String m) (TypedProgram, [Report String])
 typecheck p = second (second $ fmap fromTypecheckError) $
               first toDiagnostic $ runExcept (runWriterT (evalStateT (typecheckProgram p) (0, Ctx mempty mempty mempty Nothing)))
   where toDiagnostic = (diagnostic <++>) . fromTypecheckError
@@ -53,11 +54,11 @@ typecheck p = second (second $ fmap fromTypecheckError) $
 -- | Entry point of the typechecker.
 --
 --   Typechecks a program, and return an elaborated form of it.
-typecheckProgram :: Program -> Typechecker Program
-typecheckProgram p@(Program []) = pure p
+typecheckProgram :: Program -> Typechecker TypedProgram
+typecheckProgram p@(Program []) = pure (TProgram [])
 typecheckProgram (Program stts) = do
   registerAllLabels stts
-  res <- Program <$> mapM typecheckStatement stts
+  res <- TProgram <$> mapM typecheckStatement stts
 
   -- Check that the type of `main` is actually usable, and that states
   -- can be guaranteed at compile time.
@@ -99,13 +100,13 @@ registerAllLabels = mapM_ addLabelType . filter isLabel
 --   and add kind bindings of the @forall@ if there is one.
 --
 --   When it's an instruction, just typecheck the instruction accordingly.
-typecheckStatement :: Located Statement -> Typechecker (Located Statement)
-typecheckStatement s@(Label name ty :@ _) = do
+typecheckStatement :: Located Statement -> Typechecker (Located TypedStatement)
+typecheckStatement (Label name ty :@ p) = do
   let (binders, record) = removeForallQuantifierIfAny ty
   setCurrentTypeContext (toRegisterMap record)
   setCurrentKindContext (Map.fromList $ first toVarName <$> binders)
   setLabel name
-  pure s
+  pure (TLabel name :@ p)
  where
    removeForallQuantifierIfAny (unLoc -> ForAll b ty) = (b, ty)
    removeForallQuantifierIfAny ty                     = (mempty, ty)
@@ -115,167 +116,13 @@ typecheckStatement s@(Label name ty :@ _) = do
 
    toVarName (Var v :@ _) = v
    toVarName (t :@ _)     = error $ "Cannot get name of non-type variable type '" <> show t <> "'."
-typecheckStatement s@(Instr i :@ p)       = do
-  typecheckInstruction i p
-  pure s
+typecheckStatement (Instr i :@ p)       = do
+  (:@ p) <$> typecheckInstruction i p
 
-typecheckInstruction :: Instruction -> Position -> Typechecker ()
-typecheckInstruction i p = case i of
-  RET -> do
-    -- `reŧ` needs the return address on top of the stack.
-    -- Any remainding register values are left to the developer to choose.
-    --
-    -- So when a `reŧ` comes, the stack (so `%rsp` on x64) needs to be
-    -- `sptr *r0::s0` where `r0` is a record.
-    --
-    --
-    -- According to the x86 docs, we could also make `ret` take one parameter:
-    -- a number of bytes to pop off the stack, after popping the return address off.
-    -- While this may be useful, I won't handle this because it won't probably
-    -- be useful in N*, as a language backend.
-
-    -- if the unification suceeded, we know that there is a pointer to some sort of context
-    -- on top of the stack, which we may pop and compare to the current context.
-
-    -- TODO: check that when can return
-    -- 1- we must have crossed a label at some point. We will take the last found
-    -- 2- we must be able to extract a pointer to a context, on top of the stack
-    -- 3- everything we want to return in the context must already be found in the current context
-
-    funName <- gets (currentLabel . snd) >>= \case
-      Nothing -> throwError (ToplevelReturn p)
-      Just l  -> pure l
-
-
-    stackVar <- freshVar "@" p
-    let minimalCtx = Record (Map.singleton (RSP :@ p) (SPtr (Cons (Ptr (Record mempty :@ p) :@ p) stackVar :@ p) :@ p)) :@ p
-    currentCtx <- gets (currentTypeContext . snd)
-
-    catchError (unify minimalCtx (Record currentCtx :@ p))
-               (const $ throwError (NoReturnAddress p currentCtx))
-
-
-    let removeStackTop (SPtr (Cons _ t :@ _) :@ p1) = SPtr t :@ p1
-        removeStackTop (t :@ _)                     = error $ "Cannot extract stack top of type '" <> show t <> "'"
-
-        getStackTop (SPtr (Cons t _ :@ _) :@ _) = t
-        getStackTop (t :@ _)                    = error $ "Cannot extract stack top of type '" <> show t <> "'"
-
-    let returnShouldBe = Ptr (Record (Map.adjust removeStackTop (RSP :@ p) currentCtx) :@ p) :@ p
-        returnCtx = getStackTop $ fromJust (Map.lookup (RSP :@ p) currentCtx)
-
-    let changeErrorIfMissingKey (DomainsDoNotSubtype (m1 :@ _) (m2 :@ _)) =
-          ContextIsMissingOnReturn p (getPos returnCtx) (Map.keysSet m1 Set.\\ Map.keysSet m2)
-        changeErrorIfMissingKey e                                         = e
-
-    catchError (unify returnCtx returnShouldBe)
-               (throwError . changeErrorIfMissingKey)
-    pure ()
-  MOV (src :@ p1) (dest :@ p2) -> do
-    -- There are many ways of handling `mov`s, and it all depends on what arguments are given.
-    --
-    -- > mov <immediate>, <register>
-    -- sets "<register>: typeof (<immediate>)" in the current context
-    -- > mov <register2>, <register1>
-    -- sets "<register1>: typeof (<register2>)" in the current context
-    -- > mov <immediate>, (<address:type>)
-    -- TODO: UNSAFE ???
-    -- > mov (<address:type>), <register>
-    -- UNSAFE sets "<register>: <type>" in the current context
-    -- > mov (<address2:type2>), (<address1:type1>)
-    -- TODO: UNSAFE ???
-    -- > mov <immediate>, <offset>(<register>)
-    -- UNSAFE assert that `<register>: *typeof (<immediate>)` and leave the context untouched
-    -- > mov <register2>, <offset>(<register1>)
-    -- UNSAFE assert that `<register1>: *typeof (<register2>)` and leave the context untouched
-    --
-    --
-    -- For all those assertions, we also have to check that type sizes do match.
-    case (src, dest) of
-      (Imm i, Reg r) -> do
-        ty <- typecheckExpr src p1
-        -- TODO: size check
-        -- At the moment, this isn't a problem: we only handle immediates that are actually
-        -- smaller than the max size (8 bytes) possible.
-        gets (currentTypeContext . snd) >>= setCurrentTypeContext . Map.insert r ty
-      (Reg r1, Reg r2) -> do
-        ty1 <- typecheckExpr src p1
-        -- TODO: size check
-        -- No need at the moment, we only have 8-bytes big registers.
-        gets (currentTypeContext . snd) >>= setCurrentTypeContext . Map.insert r2 ty1
-      _ -> error $ "Missing `mov` typechecking implementation for '" <> show src <> "' and '" <> show dest <> "'."
-  _ -> pure ()
-
-typecheckExpr :: Expr -> Position -> Typechecker (Located Type)
-typecheckExpr (Imm (I _ :@ _)) p  = pure (Unsigned 64 :@ p)
-typecheckExpr (Imm (C _ :@ _)) p  = pure (Signed 8 :@ p)
-typecheckExpr (Reg r) p           = do
-  ctx <- gets (currentTypeContext . snd)
-  maybe (throwError (RegisterNotFoundInContext (unLoc r) p (Map.keysSet ctx))) pure (Map.lookup r ctx)
-typecheckExpr (Indexed _ e) p     = typecheckExpr (unLoc e) p
-typecheckExpr e p                 = error $ "Unimplemented `typecheckExpr` for '" <> show e <> "'."
-
---------------------------------------------------------------------------------
-
--- | Generates a fresh free type variable based on a given prefix, for the current source position.
-freshVar :: Text -> Position -> Typechecker (Located Type)
-freshVar prefix pos = do
-  n <- gets fst
-  incrementCounter
-  pure (FVar ((prefix <> Text.pack (show n)) :@ pos) :@ pos)
-
--- | Unifies two types, and returns the substitution from the first to the second.
-unify :: (t ~ Located Type) => t -> t -> Typechecker (Subst t)
-unify (t1 :@ p1) (t2 :@ p2) = case (t1, t2) of
-  _ | t1 == t2 -> pure mempty
-  -- Signed types are all coercible.
-  (Signed _, Signed _) -> pure mempty
-  -- Unsigned types are all coercible.
-  (Unsigned _, Unsigned _) -> pure mempty
-  -- Signed and unsigned integers can also be coerced to each other.
-  (Signed _, Unsigned _) -> pure mempty
-  (Unsigned _, Signed _) -> pure mempty
-  -- Two pointers are coercible if their pointed types are coercible.
-  (Ptr t1, Ptr t2) -> unify t1 t2
-  (SPtr t1, SPtr t2) -> unify t1 t2
-  -- Free type variables can be bound to anything as long as it does not create an infinite type.
-  (FVar v, t) -> bind (v, p1) (t, p2)
-  (t, FVar v) -> bind (v, p2) (t, p1)
-  -- FIXME: Handle records properly
-  (Record m1, Record m2) -> do
-    -- @m2@ should contain at least all the keys in @m1@:
-    let k1 = Map.keysSet m1
-        k2 = Map.keysSet m2
-    if not (k1 `Set.isSubsetOf` k2)
-    then throwError (DomainsDoNotSubtype (m1 :@ p1) (m2 :@ p2))
-    else do
-      -- All the values from the keys of @m1@ in @m2@ should be 'unify'able with the values in @m1@:
-      let doUnify k v = catchError (unify v (m2 Map.! k)) (\ e -> throwError $ RecordUnify e (m1 :@ p1) (m2 :@ p2))
-      subs <- fold <$> Map.traverseWithKey doUnify m1
-      pure subs
-  -- A stack constructor can be unified to another stack constructor if
-  -- both stack head and stack tail of each stack can be unified.
-  (Cons t1 t3, Cons t2 t4) -> unifyMany [t1, t3] [t2, t4]
-  -- Any other combination is not possible
-  _ -> throwError (Uncoercible (t1 :@ p1) (t2 :@ p2))
-
--- | Unifies many types, yielding the composition of all the substitutions created.
-unifyMany :: (t ~ Located Type) => [t] -> [t] -> Typechecker (Subst t)
-unifyMany [] []         = pure mempty
-unifyMany (x:xs) (y:ys) = do
-  sub1 <- unify x y
-  sub2 <- unifyMany (apply sub1 xs) (apply sub1 ys)
-  pure (sub1 <> sub2)
-unifyMany l r           =
-  error ("Could not unify " <> show l <> " and " <> show r <> " because they aren't of the same size.")
-
--- | Tries to bind a free type variable to a type, yielding a substitution from the variable to the type if
---   it succeeded.
-bind :: (Located Text, Position) -> (Type, Position) -> Typechecker (Subst (Located Type))
-bind (var, p1) (FVar v, p2)
-  | var == v              = pure mempty
-bind (var, p1) (ty, p2)
-  | occursCheck var ty    = throwError (InfiniteType (ty :@ p2) var)
-  | otherwise             = pure (Subst (Map.singleton var (ty :@ p2)))
- where
-   occursCheck v t = v `Set.member` freeVars t
+typecheckInstruction :: Instruction -> Position -> Typechecker TypedStatement
+typecheckInstruction i p = do
+  uncurry TInstr . (i :@ p ,) <$>
+    case i of
+      RET         -> tc_ret p
+      MOV src dst -> tc_mov src dst p
+      _           -> error $ "Unrecognized instruction '" <> show i <> "'."

--- a/lib/nsc-typechecker/src/Language/NStar/Typechecker/Types.hs
+++ b/lib/nsc-typechecker/src/Language/NStar/Typechecker/Types.hs
@@ -48,20 +48,6 @@ typecheck p = second (second $ fmap fromTypecheckError) $
               first toDiagnostic $ runExcept (runWriterT (evalStateT (typecheckProgram p) (0, Ctx mempty mempty mempty Nothing)))
   where toDiagnostic = (diagnostic <++>) . fromTypecheckError
 
--- | Transforms a typechcking error into a report.
-fromTypecheckError :: TypecheckError -> Report String
-fromTypecheckError (Uncoercible (t1 :@ p1) (t2 :@ p2))         = uncoercibleTypes (t1, p1) (t2, p2)
-fromTypecheckError (InfiniteType (t :@ p1) (v :@ p2))          = infiniteType (t, p1) (v, p2)
-fromTypecheckError (NoReturnAddress p ctx)                     = retWithoutReturnAddress p ctx
-fromTypecheckError (DomainsDoNotSubtype (m1 :@ p1) (m2 :@ p2)) = recordDomainsDoNotSubset (m1, p1) (m2, p2)
-fromTypecheckError (RecordUnify err (m1 :@ p1) (m2 :@ p2))     = fromTypecheckError err <> reportWarning "\n" [] [] <> recordValuesDoNotUnify (m1, p1) (m2, p2)
-                                                                                   --      ^^^^^^^^^^^^^^^^^^^^^^^^
-                                                                                   -- This is just to insert a newline between error
-fromTypecheckError (ToplevelReturn p)                          = returnAtTopLevel p
-fromTypecheckError (ContextIsMissingOnReturn p1 p2 regs)       = contextIsMissingOnReturnAt (Set.toList regs) p1 p2
-fromTypecheckError (FromReport r)                              = r
-fromTypecheckError (RegisterNotFoundInContext r p ctx)         = registerNotFoundInContext r p (Set.toList ctx)
-
 --------------------------------------------------------
 
 -- | Entry point of the typechecker.

--- a/lib/nsc-typechecker/src/Language/NStar/Typechecker/Types.hs
+++ b/lib/nsc-typechecker/src/Language/NStar/Typechecker/Types.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TupleSections #-}
 
 {-|
   Module: Language.NStar.Typechecker.Types
@@ -16,28 +17,13 @@ module Language.NStar.Typechecker.Types
 import Control.Monad.State
 import Language.NStar.Typechecker.Core
 import Language.NStar.Syntax.Core hiding (Token(..))
-import Language.NStar.Typechecker.Env (Env)
-import qualified Language.NStar.Typechecker.Env as Env
 import Data.Located
 import Data.Bifunctor (first, second)
-import Data.Text (Text)
-import qualified Data.Text as Text
-import Data.Map (Map)
 import Control.Monad.Except
 import Text.Diagnose hiding (Kind)
-import Language.NStar.Typechecker.Subst
 import Language.NStar.Typechecker.Errors
 import Control.Monad.Writer
 import qualified Data.Map as Map
-import qualified Data.Set as Set
-import Data.Set (Set)
-import Language.NStar.Typechecker.Free
-import Control.Applicative ((<|>))
-import Control.Monad (guard)
-import Data.List (union)
-import Data.Foldable (fold)
-import Debug.Trace (trace)
-import Data.Maybe (fromJust)
 import Language.NStar.Typechecker.Kinds (kindcheck)
 import Language.NStar.Typechecker.Instructions
 import Language.NStar.Typechecker.TC

--- a/lib/nsc-typechecker/src/Language/NStar/Typechecker/Types.hs
+++ b/lib/nsc-typechecker/src/Language/NStar/Typechecker/Types.hs
@@ -30,10 +30,11 @@ import Language.NStar.Typechecker.TC
 
 
 -- | Runs the typechecker on a given program, returning either an error or a well-formed program.
-typecheck :: Program -> Either (Diagnostic s String m) (TypedProgram, [Report String])
-typecheck p = second (second $ fmap fromTypecheckError) $
+typecheck :: Program -> Either (Diagnostic s String m) (TypedProgram, Diagnostic s String m)
+typecheck p = second (second toDiag) $
               first toDiagnostic $ runExcept (runWriterT (evalStateT (typecheckProgram p) (0, Ctx mempty mempty mempty Nothing)))
   where toDiagnostic = (diagnostic <++>) . fromTypecheckError
+        toDiag = foldl ((. fromTypecheckError) . (<++>)) diagnostic
 
 --------------------------------------------------------
 


### PR DESCRIPTION
Implements ideas from #16.

What has been done:
- Some type-checking modules have been moved to better places
- Type-checking an instruction returns its typed skeleton (`mov 0, %rax` gives `_ @u64 @r64`)


<!-- testing if this works -->
<input type="hidden" value="close #16" />
<!-- no, it doesn't -->